### PR TITLE
refactor: remove unnecessary dependencies

### DIFF
--- a/.changeset/shy-cows-kiss.md
+++ b/.changeset/shy-cows-kiss.md
@@ -1,0 +1,5 @@
+---
+"@knyt/tailor": patch
+---
+
+Remove unnecessary dependencies used for comparing style sheets.

--- a/.changeset/shy-cows-kiss.md
+++ b/.changeset/shy-cows-kiss.md
@@ -1,5 +1,5 @@
 ---
-"@knyt/tailor": patch
+"@knyt/tailor": minor
 ---
 
 Remove unnecessary dependencies used for comparing style sheets.

--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
     },
     "packages/glazier": {
       "name": "@knyt/glazier",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@knyt/artisan": "^0.1.0-alpha",
         "@knyt/luthier": "^0.1.0-alpha",
@@ -74,11 +74,10 @@
       "name": "@knyt/tailor",
       "version": "0.1.0",
       "dependencies": {
-        "@knyt/artisan": "^0.1.0-alpha.2",
-        "@knyt/clerk": "^0.1.0-alpha",
-        "@knyt/html-type": "^0.1.0-alpha",
-        "@knyt/weaver": "^0.1.0-alpha",
-        "@noble/hashes": "^1.7.1",
+        "@knyt/artisan": "^0.1.0",
+        "@knyt/clerk": "^0.1.0",
+        "@knyt/html-type": "^0.1.0",
+        "@knyt/weaver": "^0.1.0",
       },
     },
     "packages/tasker": {
@@ -109,8 +108,8 @@
       "name": "@knyt/weaver",
       "version": "0.1.0",
       "dependencies": {
-        "@knyt/artisan": "^0.1.0-alpha",
-        "@knyt/html-type": "^0.1.0-alpha",
+        "@knyt/artisan": "^0.1.0",
+        "@knyt/html-type": "^0.1.0",
       },
     },
   },
@@ -302,8 +301,6 @@
     "@microsoft/tsdoc": ["@microsoft/tsdoc@0.15.1", "", {}, "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw=="],
 
     "@microsoft/tsdoc-config": ["@microsoft/tsdoc-config@0.17.1", "", { "dependencies": { "@microsoft/tsdoc": "0.15.1", "ajv": "~8.12.0", "jju": "~1.4.0", "resolve": "~1.22.2" } }, "sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw=="],
-
-    "@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 

--- a/packages/tailor/package.json
+++ b/packages/tailor/package.json
@@ -38,8 +38,7 @@
     "@knyt/artisan": "^0.1.0",
     "@knyt/clerk": "^0.1.0",
     "@knyt/html-type": "^0.1.0",
-    "@knyt/weaver": "^0.1.0",
-    "@noble/hashes": "^1.7.1"
+    "@knyt/weaver": "^0.1.0"
   },
   "files": [
     "dist",

--- a/packages/tailor/src/__tests__/StyleSheet.test.ts
+++ b/packages/tailor/src/__tests__/StyleSheet.test.ts
@@ -262,6 +262,31 @@ describe("StyleSheet", () => {
         );
       });
     });
+
+    describe("equals", () => {
+      it("should return true for StyleSheets with the same rules", () => {
+        const other = StyleSheet.fromRules(rules);
+
+        expect(styleSheet.equals(other)).toBe(true);
+      });
+
+      it("should return false for StyleSheets with different rules", () => {
+        const other = StyleSheet.fromRules({
+          foo: {
+            color: "red",
+          },
+          bar: {
+            color: "blue",
+          },
+          "bar:hover": {
+            color: "yellow", // Different color
+          },
+        });
+
+        // @ts-expect-error because the types of the rules are different
+        expect(styleSheet.equals(other)).toBe(false);
+      });
+    });
   });
 
   describe("verbatim selectors", () => {


### PR DESCRIPTION
`@noble/hashes` was being used to generate hashes for comparing the contents of style sheets. The plan initially was to replace the package with native `SubtleCrypto` APIs, but on second thought, the hashing was unnecessary altogether. A simple string comparison is sufficient for our use case, so we can eliminate the dependency entirely. 😐 (doh)

The benefit of hashing the contents was to avoid comparing large strings directly, but in practice, it's negligible until the style sheets are megabytes in size, which is highly unlikely when these are typically only going to contain styles for a single component.

BREAKING CHANGE: Removed `hash` property. Style sheet contents are now compared directly as strings instead of using hashes.