### PR TITLE
fix(observables): improve `Reference` change notifications

### DIFF
--- a/.changeset/beige-colts-retire.md
+++ b/.changeset/beige-colts-retire.md
@@ -1,0 +1,8 @@
+---
+"@knyt/artisan": patch
+---
+
+Improve `Reference` implementation to emit change notifications in a more expected manner.
+
+- Updated behavior with `Reference`s to avoid notifying subscribers multiple times for the same change.
+- Fix an issue with `Reference`s where multiple synchronous changes would lead to emitting duplicate notifications to subscribers.

--- a/bun.lock
+++ b/bun.lock
@@ -44,10 +44,10 @@
         "@knyt/artisan": "^0.1.0",
         "@knyt/luthier": "^0.1.0",
         "@knyt/weaver": "^0.1.0",
+        "@types/bun": "^1.2.21",
         "happy-dom": "^17.4.4",
       },
       "devDependencies": {
-        "@types/bun": "^1.2.21",
         "knyt": "0.1.0",
       },
     },

--- a/packages/artisan/src/Observable/normalizeSubscriber.ts
+++ b/packages/artisan/src/Observable/normalizeSubscriber.ts
@@ -3,6 +3,8 @@ import type { Observable, Observer } from "./types";
 
 /**
  * Normalizes subscribe input to an observer.
+ *
+ * @internal scope: workspace
  */
 /*
  * ### Private Remarks

--- a/packages/artisan/src/Reference/__tests__/ mapRef.test.ts
+++ b/packages/artisan/src/Reference/__tests__/ mapRef.test.ts
@@ -99,22 +99,21 @@ describe("mapRef", () => {
       // Wait for initial value to be propagated
       await Promise.resolve();
 
-      // Called for the initial values from the origin,
-      // and again for when the subscription is created
-      expect(observer.next).toHaveBeenCalledTimes(2);
+      // Called for the initial value from the origin
+      expect(observer.next).toHaveBeenCalledTimes(1);
       expect(observer.next).lastCalledWith(42);
 
       origin.set({ foo: 50 });
 
       // Not called synchronously
-      expect(observer.next).toHaveBeenCalledTimes(2);
+      expect(observer.next).toHaveBeenCalledTimes(1);
 
       // Wait for origin to update
       await Promise.resolve();
       // Wait for transformed reference to update
       await Promise.resolve();
 
-      expect(observer.next).toHaveBeenCalledTimes(3);
+      expect(observer.next).toHaveBeenCalledTimes(2);
       expect(observer.next).toHaveBeenCalledWith(50);
     });
   });

--- a/packages/artisan/src/__tests__/rxjs.test.ts
+++ b/packages/artisan/src/__tests__/rxjs.test.ts
@@ -25,6 +25,7 @@ describe("rxjs integration", () => {
 
       countSignaler.complete();
 
+      expect(subscriber.mock.calls.length).toBe(2);
       expect(subscriber).toHaveBeenCalledWith(2);
       expect(subscriber).toHaveBeenCalledWith(3);
     });
@@ -39,7 +40,7 @@ describe("rxjs integration", () => {
 
       evenNum$.subscribe(subscriber);
 
-      // The subscriber should not be called synchronously for the initial value
+      // The subscriber should NOT be called synchronously for the initial value
       expect(subscriber).not.toHaveBeenCalled();
 
       await Promise.resolve();
@@ -74,6 +75,32 @@ describe("rxjs integration", () => {
 
       expect(subscriber).toHaveBeenCalledTimes(3);
       expect(subscriber).toHaveBeenLastCalledWith(4);
+    });
+  });
+
+  describe("ref.from", () => {
+    it("should create a Knyt Reference from an RxJS Observable", async () => {
+      const numbers$ = from([1, 2, 3, 4, 5]);
+      const state$ = ref.from(numbers$, 0);
+      const subscriber = mock();
+
+      state$.subscribe(subscriber);
+
+      // All side effects are asynchronous
+      expect(subscriber).not.toHaveBeenCalled();
+
+      // Because RxJS emits the the values synchronously from an array,
+      // we only need to wait for the next microtask for all of the values
+      // to be emitted.
+      await Promise.resolve();
+
+      expect(subscriber).toHaveBeenCalledTimes(6);
+      expect(subscriber).toHaveBeenNthCalledWith(1, 0);
+      expect(subscriber).toHaveBeenNthCalledWith(2, 1);
+      expect(subscriber).toHaveBeenNthCalledWith(3, 2);
+      expect(subscriber).toHaveBeenNthCalledWith(4, 3);
+      expect(subscriber).toHaveBeenNthCalledWith(5, 4);
+      expect(subscriber).toHaveBeenNthCalledWith(6, 5);
     });
   });
 });

--- a/packages/clerk/src/__tests__/Store.test.ts
+++ b/packages/clerk/src/__tests__/Store.test.ts
@@ -151,12 +151,13 @@ describe("Store", () => {
     });
   });
 
-  describe("createSubscriptionFactory", () => {
+  describe("createAccessor", () => {
     it("should support selector subscriptions", async () => {
-      const listener = mock((count: number) => {});
-      const selectCount = store.defineSelector((state) => state.count);
-      const onCountChange = store.createSubscriptionFactory(selectCount);
-      const subscription = onCountChange(listener);
+      const listener = mock();
+      const { count$ } = store.createAccessor({
+        count: (state) => state.count,
+      });
+      const subscription = count$.subscribe(listener);
 
       // Not called, because side effects are asynchronous.
       expect(listener).not.toHaveBeenCalled();
@@ -165,25 +166,25 @@ describe("Store", () => {
 
       // Called with the initial state when the subscriber is added,
       // and again when the subscription is created.
-      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenCalledTimes(1);
 
       store.incrementBy(4);
 
       // Not called, because side effects are asynchronous.
-      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenCalledTimes(1);
 
       // Wait for the store subscriber to be called.
       await Promise.resolve();
       // Wait for the selector subscriber to be called.
       await Promise.resolve();
 
-      expect(listener).toHaveBeenCalledTimes(3);
+      expect(listener).toHaveBeenCalledTimes(2);
 
       subscription.unsubscribe();
       store.incrementBy(4);
 
       // Not called, because side effects are asynchronous.
-      expect(listener).toHaveBeenCalledTimes(3);
+      expect(listener).toHaveBeenCalledTimes(2);
 
       // Wait for the store subscriber to be called.
       await Promise.resolve();
@@ -191,7 +192,7 @@ describe("Store", () => {
       await Promise.resolve();
 
       // Not called, because the subscription was unsubscribed.
-      expect(listener).toHaveBeenCalledTimes(3);
+      expect(listener).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/tasker/src/__tests__/tracking.test.ts
+++ b/packages/tasker/src/__tests__/tracking.test.ts
@@ -58,12 +58,13 @@ describe("tracking", () => {
 
       expect(result).toBe(observable);
 
+      expect(performUpdate).not.toHaveBeenCalled();
+
       // Wait a microtask for the initial emission
       await Promise.resolve();
 
-      // Called twice; once for the initial value emission,
-      // and once for the emission upon subscription.
-      expect(performUpdate).toHaveBeenCalledTimes(2);
+      // Called once for the initial value emission
+      expect(performUpdate).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -76,9 +77,8 @@ describe("tracking", () => {
       // Wait a microtask for the initial emissions
       await Promise.resolve();
 
-      // Called twice; once for the initial value emission,
-      // and once for the emission upon subscription.
-      expect(performUpdate).toHaveBeenCalledTimes(2);
+      // Called once for the initial value emission
+      expect(performUpdate).toHaveBeenCalledTimes(1);
 
       untrack(host, observable);
 
@@ -87,7 +87,7 @@ describe("tracking", () => {
       // Wait for async emission
       await Promise.resolve();
 
-      expect(performUpdate).toHaveBeenCalledTimes(2);
+      expect(performUpdate).toHaveBeenCalledTimes(1);
     });
 
     it("should return the observable when removing tracking", () => {
@@ -105,9 +105,8 @@ describe("tracking", () => {
       // Wait a microtask for the initial emissions
       await Promise.resolve();
 
-      // Called twice; once for the initial value emission,
-      // and once for the emission upon subscription.
-      expect(performUpdate).toHaveBeenCalledTimes(2);
+      // Called once for the initial value emission
+      expect(performUpdate).toHaveBeenCalledTimes(1);
 
       const curried = untrack(host);
       const result = curried(observable);
@@ -119,7 +118,7 @@ describe("tracking", () => {
       // Wait for async emission
       await Promise.resolve();
 
-      expect(performUpdate).toHaveBeenCalledTimes(2);
+      expect(performUpdate).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
- Update `Reference` behavior to avoid notifying subscribers multiple times for the same change.
- Fix issue where multiple synchronous changes emitted duplicate notifications.