### PR TITLE
Fix: Add `AnyRequest` type

### DIFF
--- a/.changeset/late-words-draw.md
+++ b/.changeset/late-words-draw.md
@@ -1,0 +1,5 @@
+---
+"@knyt/glazier": patch
+---
+
+Fix type compatibility for `AnyRequest` to support both `Request` and `BunRequest`, preventing conflicts with global `Request` types from other dependencies.

--- a/packages/glazier/demo/lib/appMode.ts
+++ b/packages/glazier/demo/lib/appMode.ts
@@ -1,7 +1,7 @@
-import { createRequestState } from "@knyt/glazier";
+import { createRequestState, type AnyRequest } from "@knyt/glazier";
 
 export const appMode = createRequestState("development");
 
-export function isDevelopment(request: Request) {
+export function isDevelopment(request: AnyRequest) {
   return appMode.from(request) === "development";
 }

--- a/packages/glazier/src/RequestState/RequestState.ts
+++ b/packages/glazier/src/RequestState/RequestState.ts
@@ -1,11 +1,24 @@
 import { BasicAssociationMap, type AssociationMap } from "@knyt/artisan";
+import type { BunRequest } from "bun";
+
+/**
+ * A union type of `Request` and `BunRequest` to accommodate different environments.
+ *
+ * @public
+ */
+// This type is necessary, because just using `Request` breaks
+// when other dependencies attach their own `Request` type to the global scope.
+// For example, Cloudflare Worker's Wrangler does this... annoying AF 😑.
+export type AnyRequest = Request | BunRequest;
 
 /**
  * An object that associates a value with a request. This is useful for
  * storing request-specific data that can be accessed later in the request
  * lifecycle.
+ *
+ * @public
  */
-export type RequestState<T> = AssociationMap<Request, T>;
+export type RequestState<T> = AssociationMap<AnyRequest, T>;
 
 /**
  * Create a RequestState instance.
@@ -17,11 +30,13 @@ export type RequestState<T> = AssociationMap<Request, T>;
  * Create a RequestState instance with an optional fallback value. The fallback value
  * is used when the request does not have an associated value. If no fallback value is
  * provided, the default value is undefined.
+ *
+ * @public
  */
 export function createRequestState<T>(fallback: T): RequestState<T>;
 export function createRequestState<T>(): RequestState<T | undefined>;
 export function createRequestState<T>(
   fallback?: T,
 ): RequestState<T | undefined> {
-  return new BasicAssociationMap<Request, T>(fallback);
+  return new BasicAssociationMap<AnyRequest, T>(fallback);
 }


### PR DESCRIPTION
Fix type compatibility for `AnyRequest` to support both `Request` and `BunRequest`, preventing conflicts with global `Request` types from other dependencies.